### PR TITLE
Support for back channel logout for all user sessions for a given user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@ GO ?= go
 GOLANGCILINT ?= golangci-lint
 
 BINARY := oauth2-proxy
-VERSION ?= $(shell git describe --always --dirty --tags 2>/dev/null || echo "undefined")
+#VERSION ?= $(shell git describe --always --dirty --tags 2>/dev/null || echo "undefined")
 # Allow to override image registry.
-REGISTRY ?= quay.io/oauth2-proxy
+#REGISTRY ?= quay.io/oauth2-proxy
+REGISTRY ?= arpitarathi
+VERSION ?= 1.0.0
 .NOTPARALLEL:
 
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
@@ -39,7 +41,8 @@ build: validate-go-version clean $(BINARY)
 $(BINARY):
 	CGO_ENABLED=0 $(GO) build -a -installsuffix cgo -ldflags="-X main.VERSION=${VERSION}" -o $@ github.com/oauth2-proxy/oauth2-proxy/v7
 
-DOCKER_BUILD_PLATFORM ?= linux/amd64,linux/ppc64le,linux/arm/v6,linux/arm/v8
+#DOCKER_BUILD_PLATFORM ?= linux/amd64,linux/ppc64le,linux/arm/v6,linux/arm/v8
+DOCKER_BUILD_PLATFORM ?= linux/amd64
 DOCKER_BUILD_RUNTIME_IMAGE ?= alpine:3.17.2
 DOCKER_BUILDX_ARGS ?= --build-arg RUNTIME_IMAGE=${DOCKER_BUILD_RUNTIME_IMAGE}
 DOCKER_BUILDX := docker buildx build ${DOCKER_BUILDX_ARGS} --build-arg VERSION=${VERSION}
@@ -49,7 +52,7 @@ DOCKER_BUILDX_PUSH_X_PLATFORM := $(DOCKER_BUILDX_PUSH) --platform ${DOCKER_BUILD
 
 .PHONY: docker
 docker:
-	$(DOCKER_BUILDX_X_PLATFORM) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:latest .
+	$(DOCKER_BUILDX_X_PLATFORM) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:1.0.3 .
 
 .PHONY: docker-all
 docker-all: docker
@@ -65,7 +68,7 @@ docker-all: docker
 
 .PHONY: docker-push
 docker-push:
-	$(DOCKER_BUILDX_PUSH_X_PLATFORM) -t $(REGISTRY)/oauth2-proxy:latest .
+	$(DOCKER_BUILDX_PUSH_X_PLATFORM) -t $(REGISTRY)/oauth2-proxy:1.0.3 .
 
 .PHONY: docker-push-all
 docker-push-all: docker-push

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINARY := oauth2-proxy
 # Allow to override image registry.
 #REGISTRY ?= quay.io/oauth2-proxy
 REGISTRY ?= arpitarathi
-VERSION ?= 1.0.19
+VERSION ?= 1.0.26
 .NOTPARALLEL:
 
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINARY := oauth2-proxy
 # Allow to override image registry.
 #REGISTRY ?= quay.io/oauth2-proxy
 REGISTRY ?= arpitarathi
-VERSION ?= 1.0.26
+VERSION ?= 1.0.28
 .NOTPARALLEL:
 
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINARY := oauth2-proxy
 # Allow to override image registry.
 #REGISTRY ?= quay.io/oauth2-proxy
 REGISTRY ?= arpitarathi
-VERSION ?= 1.0.28
+VERSION ?= 1.0.31
 .NOTPARALLEL:
 
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINARY := oauth2-proxy
 # Allow to override image registry.
 #REGISTRY ?= quay.io/oauth2-proxy
 REGISTRY ?= arpitarathi
-VERSION ?= 1.0.10
+VERSION ?= 1.0.19
 .NOTPARALLEL:
 
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINARY := oauth2-proxy
 # Allow to override image registry.
 #REGISTRY ?= quay.io/oauth2-proxy
 REGISTRY ?= arpitarathi
-VERSION ?= 1.0.0
+VERSION ?= 1.0.10
 .NOTPARALLEL:
 
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
@@ -52,7 +52,7 @@ DOCKER_BUILDX_PUSH_X_PLATFORM := $(DOCKER_BUILDX_PUSH) --platform ${DOCKER_BUILD
 
 .PHONY: docker
 docker:
-	$(DOCKER_BUILDX_X_PLATFORM) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:1.0.3 .
+	$(DOCKER_BUILDX_X_PLATFORM) -f Dockerfile -t $(REGISTRY)/oauth2-proxy:$(VERSION) .
 
 .PHONY: docker-all
 docker-all: docker
@@ -68,7 +68,7 @@ docker-all: docker
 
 .PHONY: docker-push
 docker-push:
-	$(DOCKER_BUILDX_PUSH_X_PLATFORM) -t $(REGISTRY)/oauth2-proxy:1.0.3 .
+	$(DOCKER_BUILDX_PUSH_X_PLATFORM) -t $(REGISTRY)/oauth2-proxy:$(VERSION) .
 
 .PHONY: docker-push-all
 docker-push-all: docker-push

--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -298,6 +298,9 @@ func (p *OAuthProxy) buildServeMux(proxyPrefix string) {
 	// Register the robots path writer
 	r.Path(robotsPath).HandlerFunc(p.pageWriter.WriteRobotsTxt)
 
+	// Register clear all user sessions
+	r.Path(clearUserSessions).HandlerFunc(p.ClearUserSessions)
+
 	// The authonly path should be registered separately to prevent it from getting no-cache headers.
 	// We do this to allow users to have a short cache (via nginx) of the response to reduce the
 	// likelihood of multiple reuests trying to referesh sessions simultaneously.
@@ -737,12 +740,13 @@ func (p *OAuthProxy) SignOut(rw http.ResponseWriter, req *http.Request) {
 
 // ClearUserSessions sends a response to clear all sessions for a given user
 func (p *OAuthProxy) ClearUserSessions(rw http.ResponseWriter, req *http.Request) {
-	_, err := p.getAuthenticatedSession(rw, req)
-	if err != nil {
-		http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
-		return
-	}
-	err = p.ClearAllSessionCookies(rw, req, req.URL.Query().Get("userid"))
+	// _, err := p.getAuthenticatedSession(rw, req)
+	// if err != nil {
+	// 	http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+	// 	return
+	// }
+	fmt.Printf("Inside ClearUserSessions function\n")
+	err := p.ClearAllSessionCookies(rw, req, req.URL.Query().Get("user_id"))
 	if err != nil {
 		logger.Errorf("Error clearing session cookies for user: %v", err)
 		p.ErrorPage(rw, req, http.StatusInternalServerError, err.Error())

--- a/pkg/apis/sessions/interfaces.go
+++ b/pkg/apis/sessions/interfaces.go
@@ -12,7 +12,7 @@ type SessionStore interface {
 	Save(rw http.ResponseWriter, req *http.Request, s *SessionState) error
 	Load(req *http.Request) (*SessionState, error)
 	Clear(rw http.ResponseWriter, req *http.Request) error
-	ClearAll(rw http.ResponseWriter, req *http.Request, user string) error
+	ClearAll(rw http.ResponseWriter, req *http.Request, password string, user string) error
 	VerifyConnection(ctx context.Context) error
 }
 

--- a/pkg/apis/sessions/interfaces.go
+++ b/pkg/apis/sessions/interfaces.go
@@ -12,7 +12,7 @@ type SessionStore interface {
 	Save(rw http.ResponseWriter, req *http.Request, s *SessionState) error
 	Load(req *http.Request) (*SessionState, error)
 	Clear(rw http.ResponseWriter, req *http.Request) error
-	ClearAll(rw http.ResponseWriter, req *http.Request, password string, user string) error
+	ClearAll(rw http.ResponseWriter, req *http.Request, s *SessionState, password string, user string) error
 	VerifyConnection(ctx context.Context) error
 }
 

--- a/pkg/apis/sessions/interfaces.go
+++ b/pkg/apis/sessions/interfaces.go
@@ -12,6 +12,7 @@ type SessionStore interface {
 	Save(rw http.ResponseWriter, req *http.Request, s *SessionState) error
 	Load(req *http.Request) (*SessionState, error)
 	Clear(rw http.ResponseWriter, req *http.Request) error
+	ClearAll(rw http.ResponseWriter, req *http.Request, user string) error
 	VerifyConnection(ctx context.Context) error
 }
 

--- a/pkg/middleware/stored_session_test.go
+++ b/pkg/middleware/stored_session_test.go
@@ -794,6 +794,9 @@ func (f *fakeSessionStore) Clear(rw http.ResponseWriter, req *http.Request) erro
 	return nil
 }
 
+func (f *fakeSessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, user string) error {
+	return nil
+}
 func (f *fakeSessionStore) VerifyConnection(_ context.Context) error {
 	return nil
 }

--- a/pkg/middleware/stored_session_test.go
+++ b/pkg/middleware/stored_session_test.go
@@ -794,7 +794,7 @@ func (f *fakeSessionStore) Clear(rw http.ResponseWriter, req *http.Request) erro
 	return nil
 }
 
-func (f *fakeSessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, user string) error {
+func (f *fakeSessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, password string, user string) error {
 	return nil
 }
 func (f *fakeSessionStore) VerifyConnection(_ context.Context) error {

--- a/pkg/middleware/stored_session_test.go
+++ b/pkg/middleware/stored_session_test.go
@@ -794,7 +794,7 @@ func (f *fakeSessionStore) Clear(rw http.ResponseWriter, req *http.Request) erro
 	return nil
 }
 
-func (f *fakeSessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, password string, user string) error {
+func (f *fakeSessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, s *sessionsapi.SessionState, string, user string) error {
 	return nil
 }
 func (f *fakeSessionStore) VerifyConnection(_ context.Context) error {

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -83,6 +83,12 @@ func (s *SessionStore) Clear(rw http.ResponseWriter, req *http.Request) error {
 	return nil
 }
 
+// ClearAll clears all saved sessions' information for a given user
+// from redis, and then clears the session. Not implemented for cookie
+func (s *SessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, user string) error {
+	return nil
+}
+
 // VerifyConnection always return no-error, as there's no connection
 // in this store
 func (s *SessionStore) VerifyConnection(_ context.Context) error {

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -85,8 +85,7 @@ func (s *SessionStore) Clear(rw http.ResponseWriter, req *http.Request) error {
 
 // ClearAll clears all saved sessions' information for a given user
 // from redis, and then clears the session. Not implemented for cookie
-func (s *SessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, password string, user string) error {
-	fmt.Printf("Inside clearAll for cookie interface\n")
+func (s *SessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, ss *sessions.SessionState, string, user string) error {
 	return errors.New("access denied")
 }
 

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -85,9 +85,9 @@ func (s *SessionStore) Clear(rw http.ResponseWriter, req *http.Request) error {
 
 // ClearAll clears all saved sessions' information for a given user
 // from redis, and then clears the session. Not implemented for cookie
-func (s *SessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, user string) error {
+func (s *SessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, password string, user string) error {
 	fmt.Printf("Inside clearAll for cookie interface\n")
-	return nil
+	return errors.New("access denied")
 }
 
 // VerifyConnection always return no-error, as there's no connection

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -86,6 +86,7 @@ func (s *SessionStore) Clear(rw http.ResponseWriter, req *http.Request) error {
 // ClearAll clears all saved sessions' information for a given user
 // from redis, and then clears the session. Not implemented for cookie
 func (s *SessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, user string) error {
+	fmt.Printf("Inside clearAll for cookie interface\n")
 	return nil
 }
 

--- a/pkg/sessions/cookie/session_store.go
+++ b/pkg/sessions/cookie/session_store.go
@@ -85,8 +85,12 @@ func (s *SessionStore) Clear(rw http.ResponseWriter, req *http.Request) error {
 
 // ClearAll clears all saved sessions' information for a given user
 // from redis, and then clears the session. Not implemented for cookie
-func (s *SessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, ss *sessions.SessionState, string, user string) error {
+func (s *SessionStore) ClearAll(rw http.ResponseWriter, req *http.Request, ss *sessions.SessionState, password string, user string) error {
 	return errors.New("access denied")
+}
+
+func (store *SessionStore) SaveUserSession(ctx context.Context, s *sessions.SessionState, value string, exp time.Duration) error {
+	return nil
 }
 
 // VerifyConnection always return no-error, as there's no connection

--- a/pkg/sessions/persistence/interfaces.go
+++ b/pkg/sessions/persistence/interfaces.go
@@ -12,9 +12,10 @@ import (
 // for session ticket + encryption details.
 type Store interface {
 	Save(context.Context, string, []byte, time.Duration) error
+	SaveUserSession(context.Context, *sessions.SessionState, string, time.Duration) error
 	Load(context.Context, string) ([]byte, error)
 	Clear(context.Context, string) error
-	ClearAll(context.Context, *sessions.SessionState, time.Duration, string, string, string) error
+	ClearAll(context.Context, *sessions.SessionState, time.Duration, string, string) error
 	Lock(key string) sessions.Lock
 	VerifyConnection(context.Context) error
 }

--- a/pkg/sessions/persistence/interfaces.go
+++ b/pkg/sessions/persistence/interfaces.go
@@ -14,6 +14,7 @@ type Store interface {
 	Save(context.Context, string, []byte, time.Duration) error
 	Load(context.Context, string) ([]byte, error)
 	Clear(context.Context, string) error
+	ClearAll(context.Context, string, string) error
 	Lock(key string) sessions.Lock
 	VerifyConnection(context.Context) error
 }

--- a/pkg/sessions/persistence/interfaces.go
+++ b/pkg/sessions/persistence/interfaces.go
@@ -14,7 +14,7 @@ type Store interface {
 	Save(context.Context, string, []byte, time.Duration) error
 	Load(context.Context, string) ([]byte, error)
 	Clear(context.Context, string) error
-	ClearAll(context.Context, string, string) error
+	ClearAll(context.Context, string, string, string) error
 	Lock(key string) sessions.Lock
 	VerifyConnection(context.Context) error
 }

--- a/pkg/sessions/persistence/interfaces.go
+++ b/pkg/sessions/persistence/interfaces.go
@@ -14,7 +14,7 @@ type Store interface {
 	Save(context.Context, string, []byte, time.Duration) error
 	Load(context.Context, string) ([]byte, error)
 	Clear(context.Context, string) error
-	ClearAll(context.Context, string, string, string) error
+	ClearAll(context.Context, *sessions.SessionState, time.Duration, string, string, string) error
 	Lock(key string) sessions.Lock
 	VerifyConnection(context.Context) error
 }

--- a/pkg/sessions/persistence/manager.go
+++ b/pkg/sessions/persistence/manager.go
@@ -121,6 +121,7 @@ func (m *Manager) Clear(rw http.ResponseWriter, req *http.Request) error {
 // Clear clears any saved session information for a given ticket cookie.
 // Then it clears all session data for that ticket in the Store.
 func (m *Manager) ClearAll(rw http.ResponseWriter, req *http.Request, user string) error {
+	fmt.Printf("Inside ClearAll function in Manager.go\n")
 	tckt, err := decodeTicketFromRequest(req, m.Options)
 	if err != nil {
 		// Always clear the cookie, even when we can't load a cookie from

--- a/pkg/sessions/persistence/manager.go
+++ b/pkg/sessions/persistence/manager.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/options"
 	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/apis/sessions"
-	"github.com/oauth2-proxy/oauth2-proxy/v7/pkg/logger"
 )
 
 // Manager wraps a Store and handles the implementation details of the
@@ -43,25 +41,11 @@ func (m *Manager) Save(rw http.ResponseWriter, req *http.Request, s *sessions.Se
 			return fmt.Errorf("error creating a session ticket: %v", err)
 		}
 	}
-	// // Start
-	// if _, ok := interface{}(m.Store).(*redis.SessionStore); ok {
-	keyName := fmt.Sprintf("sessionlist-%s", s.User)
-	keyVal, keyerr := m.Store.Load(req.Context(), keyName)
-	var ticket []byte
-	if keyerr != nil {
-		ticket = []byte(tckt.id)
-	} else if !(strings.Contains(string(keyVal), tckt.id)) {
-		ticket = []byte(fmt.Sprintf("%s:%s", keyVal, tckt.id))
-	} else {
-		ticket = keyVal
-	}
 
-	err = saveSessionKey(req.Context(), keyName, ticket, tckt.options.Expire, m, s)
+	err = m.Store.SaveUserSession(req.Context(), s, tckt.id, tckt.options.Expire)
 	if err != nil {
 		return err
 	}
-	// }
-	// // End
 
 	err = tckt.saveSession(s, func(key string, val []byte, exp time.Duration) error {
 		return m.Store.Save(req.Context(), key, val, exp)
@@ -73,22 +57,9 @@ func (m *Manager) Save(rw http.ResponseWriter, req *http.Request, s *sessions.Se
 	return tckt.setCookie(rw, req, s)
 }
 
-func saveSessionKey(ctx context.Context, keyName string, ticket []byte, exp time.Duration, m *Manager, s *sessions.SessionState) error {
-	err := s.ObtainLock(ctx, exp)
-	if err != nil {
-		return fmt.Errorf("error occurred while trying to obtain lock: %v", err)
-	}
-	defer func() {
-		if s == nil {
-			return
-		}
-		if err := s.ReleaseLock(ctx); err != nil {
-			logger.Errorf("unable to release lock: %v", err)
-		}
-	}()
-	err = m.Store.Save(ctx, keyName, ticket, exp)
-	return err
-}
+// func (m *Manager) SaveUserSession(ctx context.Context, s *sessions.SessionState, value string, exp time.Duration) error {
+// 	return m.Store.SaveUserSession(ctx, s, value, exp)
+// }
 
 // Load reads sessions.SessionState information from a session store. It will
 // use the session ticket from the http.Request's cookie.
@@ -130,29 +101,9 @@ func (m *Manager) Clear(rw http.ResponseWriter, req *http.Request) error {
 	})
 }
 
-// Clear clears any saved session information for a given ticket cookie.
-// Then it clears all session data for that ticket in the Store.
+// ClearAll clears any saved session information for a given user.
 func (m *Manager) ClearAll(rw http.ResponseWriter, req *http.Request, s *sessions.SessionState, password string, user string) error {
-	tckt, err := decodeTicketFromRequest(req, m.Options)
-	if err != nil {
-		// Always clear the cookie, even when we can't load a cookie from
-		// the request
-		tckt = &ticket{
-			options: m.Options,
-		}
-		tckt.clearCookie(rw, req)
-		// Don't raise an error if we didn't have a Cookie
-		if err == http.ErrNoCookie {
-			return nil
-		}
-		return fmt.Errorf("error decoding ticket to clear session: %v", err)
-	}
-
-	tckt.clearCookie(rw, req)
-	err = tckt.clearSession(func(key string) error {
-		return m.Store.ClearAll(req.Context(), s, tckt.options.Expire, key, password, user)
-	})
-	return err
+	return m.Store.ClearAll(req.Context(), s, m.Options.Expire, password, user)
 }
 
 // VerifyConnection validates the underlying store is ready and connected

--- a/pkg/sessions/persistence/ticket.go
+++ b/pkg/sessions/persistence/ticket.go
@@ -57,11 +57,6 @@ func newTicket(cookieOpts *options.Cookie) (*ticket, error) {
 	if _, err := io.ReadFull(rand.Reader, secret); err != nil {
 		return nil, fmt.Errorf("failed to create encryption secret: %v", err)
 	}
-	// fmt.Printf("Information in newTicket *******")
-	// fmt.Printf("ticketID : %v\n", ticketID)
-	// fmt.Printf("secret : %v\n", secret)
-	// fmt.Printf("cookieOpts : %v\n", cookieOpts)
-	// fmt.Printf("*cookieOpts : %v\n", *cookieOpts)
 
 	return &ticket{
 		id:      ticketID,

--- a/pkg/sessions/persistence/ticket.go
+++ b/pkg/sessions/persistence/ticket.go
@@ -57,11 +57,11 @@ func newTicket(cookieOpts *options.Cookie) (*ticket, error) {
 	if _, err := io.ReadFull(rand.Reader, secret); err != nil {
 		return nil, fmt.Errorf("failed to create encryption secret: %v", err)
 	}
-	fmt.Printf("Information in newTicket *******")
-	fmt.Printf("ticketID : %v\n", ticketID)
-	fmt.Printf("secret : %v\n", secret)
-	fmt.Printf("cookieOpts : %v\n", cookieOpts)
-	fmt.Printf("*cookieOpts : %v\n", *cookieOpts)
+	// fmt.Printf("Information in newTicket *******")
+	// fmt.Printf("ticketID : %v\n", ticketID)
+	// fmt.Printf("secret : %v\n", secret)
+	// fmt.Printf("cookieOpts : %v\n", cookieOpts)
+	// fmt.Printf("*cookieOpts : %v\n", *cookieOpts)
 
 	return &ticket{
 		id:      ticketID,

--- a/pkg/sessions/persistence/ticket.go
+++ b/pkg/sessions/persistence/ticket.go
@@ -57,6 +57,11 @@ func newTicket(cookieOpts *options.Cookie) (*ticket, error) {
 	if _, err := io.ReadFull(rand.Reader, secret); err != nil {
 		return nil, fmt.Errorf("failed to create encryption secret: %v", err)
 	}
+	fmt.Printf("Information in newTicket *******")
+	fmt.Printf("ticketID : %v\n", ticketID)
+	fmt.Printf("secret : %v\n", secret)
+	fmt.Printf("cookieOpts : %v\n", cookieOpts)
+	fmt.Printf("*cookieOpts : %v\n", *cookieOpts)
 
 	return &ticket{
 		id:      ticketID,

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -50,6 +50,7 @@ func (store *SessionStore) Save(ctx context.Context, key string, value []byte, e
 // cookie within the HTTP request object
 func (store *SessionStore) Load(ctx context.Context, key string) ([]byte, error) {
 	value, err := store.Client.Get(ctx, key)
+	fmt.Printf("Value: %v", value)
 	if err != nil {
 		return nil, fmt.Errorf("error loading redis session: %v", err)
 	}
@@ -69,20 +70,26 @@ func (store *SessionStore) Clear(ctx context.Context, key string) error {
 // ClearAll clears all saved sessions' information for a given user
 // from redis, and then clears the session
 func (store *SessionStore) ClearAll(ctx context.Context, key string, user string) error {
+	fmt.Printf("Redis Clear All function called \n")
+	fmt.Printf("user: %v \n", user)
 	keyName := fmt.Sprintf("sessionlist-%s", user)
+	fmt.Printf("keyName: %v \n", keyName)
 	value, err := store.Load(ctx, keyName)
 	if err != nil {
+		fmt.Printf("Error due to store load \n")
 		return err
 	}
+	fmt.Printf("strings.Split, %v\n", strings.Split(string(value), ":"))
 	for _, sessionKey := range strings.Split(string(value), ":") {
+		fmt.Printf("sessionKey:%v\n", sessionKey)
 		err = store.Client.Del(ctx, sessionKey)
 		if err != nil {
 			return fmt.Errorf("error clearing the session %v from redis: %v", sessionKey, err)
 		}
 	}
-	err = store.Client.Del(ctx, key)
+	err = store.Client.Del(ctx, keyName)
 	if err != nil {
-		return fmt.Errorf("error clearing the session %v from redis: %v", key, err)
+		return fmt.Errorf("error clearing the session %v from redis: %v", keyName, err)
 	}
 	return nil
 }

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -50,7 +50,7 @@ func (store *SessionStore) Save(ctx context.Context, key string, value []byte, e
 // cookie within the HTTP request object
 func (store *SessionStore) Load(ctx context.Context, key string) ([]byte, error) {
 	value, err := store.Client.Get(ctx, key)
-	fmt.Printf("Value: %v", value)
+	//fmt.Printf("Value: %v", value)
 	if err != nil {
 		return nil, fmt.Errorf("error loading redis session: %v", err)
 	}
@@ -69,7 +69,7 @@ func (store *SessionStore) Clear(ctx context.Context, key string) error {
 
 // ClearAll clears all saved sessions' information for a given user
 // from redis, and then clears the session
-func (store *SessionStore) ClearAll(ctx context.Context, key string, user string) error {
+func (store *SessionStore) ClearAll(ctx context.Context, key string, password string, user string) error {
 	fmt.Printf("Redis Clear All function called \n")
 	fmt.Printf("user: %v \n", user)
 	keyName := fmt.Sprintf("sessionlist-%s", user)

--- a/pkg/sessions/redis/redis_store.go
+++ b/pkg/sessions/redis/redis_store.go
@@ -50,7 +50,6 @@ func (store *SessionStore) Save(ctx context.Context, key string, value []byte, e
 // cookie within the HTTP request object
 func (store *SessionStore) Load(ctx context.Context, key string) ([]byte, error) {
 	value, err := store.Client.Get(ctx, key)
-	//fmt.Printf("Value: %v", value)
 	if err != nil {
 		return nil, fmt.Errorf("error loading redis session: %v", err)
 	}
@@ -70,18 +69,12 @@ func (store *SessionStore) Clear(ctx context.Context, key string) error {
 // ClearAll clears all saved sessions' information for a given user
 // from redis, and then clears the session
 func (store *SessionStore) ClearAll(ctx context.Context, key string, password string, user string) error {
-	fmt.Printf("Redis Clear All function called \n")
-	fmt.Printf("user: %v \n", user)
 	keyName := fmt.Sprintf("sessionlist-%s", user)
-	fmt.Printf("keyName: %v \n", keyName)
 	value, err := store.Load(ctx, keyName)
 	if err != nil {
-		fmt.Printf("Error due to store load \n")
 		return err
 	}
-	fmt.Printf("strings.Split, %v\n", strings.Split(string(value), ":"))
 	for _, sessionKey := range strings.Split(string(value), ":") {
-		fmt.Printf("sessionKey:%v\n", sessionKey)
 		err = store.Client.Del(ctx, sessionKey)
 		if err != nil {
 			return fmt.Errorf("error clearing the session %v from redis: %v", sessionKey, err)

--- a/pkg/sessions/tests/mock_store.go
+++ b/pkg/sessions/tests/mock_store.go
@@ -57,7 +57,7 @@ func (s *MockStore) Clear(_ context.Context, key string) error {
 }
 
 // Clear deletes an entry from the memory cache
-func (s *MockStore) ClearAll(_ context.Context, key string, password string, user string) error {
+func (s *MockStore) ClearAll(_ context.Context, ss *sessions.SessionState, exp time.Duration, key string, password string, user string) error {
 	return nil
 }
 

--- a/pkg/sessions/tests/mock_store.go
+++ b/pkg/sessions/tests/mock_store.go
@@ -57,7 +57,12 @@ func (s *MockStore) Clear(_ context.Context, key string) error {
 }
 
 // Clear deletes an entry from the memory cache
-func (s *MockStore) ClearAll(_ context.Context, ss *sessions.SessionState, exp time.Duration, key string, password string, user string) error {
+func (s *MockStore) ClearAll(_ context.Context, ss *sessions.SessionState, exp time.Duration, password string, user string) error {
+	return nil
+}
+
+// Clear deletes an entry from the memory cache
+func (s *MockStore) SaveUserSession(_ context.Context, ss *sessions.SessionState, key string, exp time.Duration) error {
 	return nil
 }
 

--- a/pkg/sessions/tests/mock_store.go
+++ b/pkg/sessions/tests/mock_store.go
@@ -57,7 +57,7 @@ func (s *MockStore) Clear(_ context.Context, key string) error {
 }
 
 // Clear deletes an entry from the memory cache
-func (s *MockStore) ClearAll(_ context.Context, key string, user string) error {
+func (s *MockStore) ClearAll(_ context.Context, key string, password string, user string) error {
 	return nil
 }
 

--- a/pkg/sessions/tests/mock_store.go
+++ b/pkg/sessions/tests/mock_store.go
@@ -56,6 +56,11 @@ func (s *MockStore) Clear(_ context.Context, key string) error {
 	return nil
 }
 
+// Clear deletes an entry from the memory cache
+func (s *MockStore) ClearAll(_ context.Context, key string, user string) error {
+	return nil
+}
+
 func (s *MockStore) Lock(key string) sessions.Lock {
 	if s.lockCache[key] != nil {
 		return s.lockCache[key]


### PR DESCRIPTION
Coauthors: Om, Arpita
Support for back channel logout for all user sessions for a given user. This change is supported only for redis client. 

Changes done:
Add/Update a session-<user id> key in redis store for any new user session.
Add a new endpoint "clear_user_sessions" with mandatory query parameters : password and user_id.